### PR TITLE
Fix play slider to load properly on startup

### DIFF
--- a/AudioPlayer.h
+++ b/AudioPlayer.h
@@ -141,12 +141,6 @@
 - (AudioData *)getAudioData;
 
 /*!
- * Checks if there is any audio data loaded into the player.
- * @return Whether there is any audio data loaded into the player.
- */
-- (bool)hasAudioData;
-
-/*!
  * Finds suitable start times to loop to.
  * @return An array of suitable start times.
  */

--- a/AudioPlayer.m
+++ b/AudioPlayer.m
@@ -295,11 +295,6 @@ static const float SEARCHTOLERANCE = 300;
     return audioData;
 }
 
-- (bool)hasAudioData
-{
-    return audioData != nil;
-}
-
 - (NSMutableArray *)findLoopTime
 {
     /// Acceptable start points.

--- a/LoopMusicViewController.m
+++ b/LoopMusicViewController.m
@@ -403,10 +403,7 @@ static const double TEST_TIME_OFFSET = 5;
 }
 - (void)refreshPlaySlider
 {
-    if ([audioPlayer hasAudioData])
-    {
-        [playSlider setupNewTrack:audioPlayer.duration :audioPlayer.loopStart :audioPlayer.loopEnd];
-    }
+    [playSlider setupNewTrack:audioPlayer.duration :audioPlayer.loopStart :audioPlayer.loopEnd];
 }
 - (void)setAudioLoopStart:(NSTimeInterval)newStart
 {


### PR DESCRIPTION
`[audioPlayer hasAudioData]` check was previously redundant, now broken.